### PR TITLE
OLH-2410 - Ensure Linting job is more appropriately named.

### DIFF
--- a/.github/workflows/lint-and-validate-registry.yaml
+++ b/.github/workflows/lint-and-validate-registry.yaml
@@ -1,4 +1,4 @@
-name: Lint and validate client registry
+name: Lint
 
 on:
   workflow_call:
@@ -16,7 +16,7 @@ on:
 
 jobs:
   lint_and_test:
-    name: di-account-management-client-registry
+    name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:


### PR DESCRIPTION
## Proposed changes

OLH-2410 - Ensure Linting job is more appropriately named.

### What changed

Update job name in lint workflow

### Why did it change

Accurate naming

### Related links



## Checklists



### Testing

### Sign-offs


## How to review
