### PR TITLE
OLH-2413 - Update Backend to Use Centralized Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ logs*.json
 
 keys/
 .vscode/
+
+dist

--- a/clients/iaa.ts
+++ b/clients/iaa.ts
@@ -6,7 +6,7 @@ const iaa: Client = {
     integration: "Gk-D7WMvytB44Nze7oEC5KcThQZ4yl7sAA",
     nonProduction: "iaa",
   },
-  isAvailableInWelsh: true,
+  isAvailableInWelsh: false,
   isAllowed: true,
   clientType: "account",
   isHmrc: false,
@@ -14,19 +14,12 @@ const iaa: Client = {
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {
-      header: "Register of immigration advisers",
+      header: "Immigration Advice Authority",
       description:
         "Authorise and register an immigration adviser or organisation.",
-      linkText: "Go to your Register of immigration advisers account",
-      linkUrl: "https://portal.oisc.gov.uk/",
-    },
-    cy: {
-      header: "Cofrestr o ymgynghorwyr mewnfudo",
-      description:
-        "Awdurdodi a chofrestru ymgynghorydd neu sefydliad mewnfudo.",
-      linkText: "Ewch i'ch cyfrif Cofrestr o gynghorwyr mewnfudo",
-      linkUrl: "https://portal.oisc.gov.uk/",
-    },
+      linkText: "Go to your Immigration Advice Authority account",
+      linkUrl: "https://www.gov.uk/government/organisations/immigration-advice-authority",
+    }
   },
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     "^.+.tsx?$": ["ts-jest",{}],
   },
+  testPathIgnorePatterns: ['node_modules/', 'dist/'],
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "di-account-management-client-registry",
   "version": "1.0.0",
   "description": "",
-  "main": "index.ts",
+  "main": "dist/index.js",
   "lint-staged": {
     "*.ts": [
       "eslint --fix",
@@ -13,10 +13,12 @@
   },
   "scripts": {
     "lint": "tsc && eslint .",
-    "prepare": "husky install",
+    "prepare": "tsc && husky install",
     "precommit": "pre-commit run",
-    "test": "jest"
+    "test": "jest",
+    "build": "tsc"
   },
+  "type": "commonjs",
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "es2020",
+    "module": "CommonJS",
     "moduleResolution": "Node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
+    "noEmit": false,
     "isolatedModules": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "outDir": "./dist"
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Proposed changes

Ensure client registry can be imported as a module and demonstrate by using as a centralised library in the backend.

### What changed

Ensure ts-config generates post compiled output
configure to operate as a module


### Why did it change

So that client registry can be used as a module by other services.

### Related links


## Checklists

### Testing
Demonstrate module is importable and works by other services.

### Sign-offs

## How to review
