### PR TITLE
OLH-2414 Show the hint text and paragraphs for HMRC clients

### DIFF
--- a/src/get-translations.ts
+++ b/src/get-translations.ts
@@ -8,7 +8,10 @@ const convertToTranslation = (translations: Client["translations"]["en"], enviro
         header: translations.header,
         link_text: translations.linkText,
         link_href: getValueForEnvironment(environment, translations.linkUrl),
-        description: translations.description || undefined
+        ...translations.description && { description: translations.description },
+        ...translations.hintText && { hint_text: translations.hintText },
+        ...translations.paragraph1 && { paragraph1: translations.paragraph1 },
+        ...translations.paragraph2 && { paragraph2: translations.paragraph2 }
     }
 }
 

--- a/tests/get-translations.test.ts
+++ b/tests/get-translations.test.ts
@@ -45,6 +45,26 @@ jest.mock('../clients', () => ({
         isHmrc: false,
         isReportSuspiciousActivityEnabled: false,
         showInClientSearch: true
+    },
+    hmrcClient: {
+        isAvailableInWelsh: false,
+        translations: {
+            en: {
+                header: 'header en',
+                linkText: 'link text en',
+                linkUrl: 'link url en',
+                description: 'description en',
+                hintText: 'hint text en',
+                paragraph1: 'paragraph 1 en',
+                paragraph2: 'paragraph 2 en'
+            },
+        },
+        clientId: 'englishClient',
+        clientType: 'account',
+        isAllowed: true,
+        isHmrc: false,
+        isReportSuspiciousActivityEnabled: false,
+        showInClientSearch: true
     }
 }));
 
@@ -63,7 +83,16 @@ describe('getTranslations', () => {
                 link_text: 'link text en',
                 link_href: 'link url en',
                 description: 'description en'
-            }
+            },
+            hmrcClient: {
+                description: "description en",
+                header: "header en",
+                hint_text: "hint text en",
+                link_href: "link url en",
+                link_text: "link text en",
+                paragraph1: "paragraph 1 en",
+                paragraph2: "paragraph 2 en",
+            },
         });
     });
     test('should return transaltions in welsh', async () => {
@@ -80,6 +109,15 @@ describe('getTranslations', () => {
                 link_text: 'link text en',
                 link_href: 'link url en',
                 description: 'description en'
+            },
+            hmrcClient: {
+                description: "description en",
+                header: "header en",
+                hint_text: "hint text en",
+                link_href: "link url en",
+                link_text: "link text en",
+                paragraph1: "paragraph 1 en",
+                paragraph2: "paragraph 2 en",
             }
         });
     })
@@ -97,6 +135,15 @@ describe('getTranslations', () => {
                 link_text: 'link text en',
                 link_href: 'link url en',
                 description: 'description en'
+            },
+            hmrcClient: {
+                description: "description en",
+                header: "header en",
+                hint_text: "hint text en",
+                link_href: "link url en",
+                link_text: "link text en",
+                paragraph1: "paragraph 1 en",
+                paragraph2: "paragraph 2 en",
             }
         });
     })

--- a/tests/get-translations.test.ts
+++ b/tests/get-translations.test.ts
@@ -10,7 +10,6 @@ jest.mock('../clients', () => ({
                 header: 'header en',
                 linkText: 'link text en',
                 linkUrl: 'link url en',
-                description: 'description en'
             },
             cy: {
                 header: 'header cy',
@@ -19,7 +18,6 @@ jest.mock('../clients', () => ({
                     production: 'link url cy production',
                     nonProduction: 'link url cy non production'
                 },
-                description: 'description cy'
             }
         },
         clientId: 'welshClient',
@@ -71,12 +69,11 @@ jest.mock('../clients', () => ({
 describe('getTranslations', () => {
     test('should return translations in english', async () => {
         const translations = getTranslations('test', 'en');
-        expect(translations).toEqual({
+        expect(translations).toStrictEqual({
             cyClient: {
                 header: 'header en',
                 link_text: 'link text en',
                 link_href: 'link url en',
-                description: 'description en'
             },
             enClient: {
                 header: 'header en',
@@ -97,12 +94,11 @@ describe('getTranslations', () => {
     });
     test('should return transaltions in welsh', async () => {
         const translations = getTranslations('test', 'cy');
-        expect(translations).toEqual({
+        expect(translations).toStrictEqual({
             cyClient: {
                 header: 'header cy',
                 link_text: 'link text cy',
                 link_href: 'link url cy non production',
-                description: 'description cy'
             },
             enClient: {
                 header: 'header en',
@@ -123,12 +119,11 @@ describe('getTranslations', () => {
     })
     test('should return correct environment varialbes', async () => {
         const translations = getTranslations('production', 'cy');
-        expect(translations).toEqual({
+        expect(translations).toStrictEqual({
             cyClient: {
                 header: 'header cy',
                 link_text: 'link text cy',
                 link_href: 'link url cy production',
-                description: 'description cy'
             },
             enClient: {
                 header: 'header en',


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

If there is a hint_text, paragraph1 and paragraph2 field in the transaltions, pass that through in the getTranslations function

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

- [ ] Application configuration is up-to-date
- [ ] Documented in the README

### Testing

### Sign-offs

- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
