### PR TITLE
OLH-2437 - Ensure we use the latest version of the library whenever we deploy

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,6 @@
 import getTranslations from './src/get-translations'
+import {Translation} from './interfaces/translations.interface'
+import {TranslationsObject} from './interfaces/translations.interface'
 
 export { getTranslations }
+export type { Translation, TranslationsObject }


### PR DESCRIPTION

## Proposed changes

OLH-2437 - Ensure we use the latest version of the library whenever we deploy

### What changed

Fix issue with exporting types as part of library

### Why did it change

So that external modules can use the library

### Related links

https://govukverify.atlassian.net/browse/OLH-2437

## Checklists

### Testing

### Sign-offs

## How to review