### PR TITLE
OLH-2460 Add ability to return a filtered client array.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import getTranslations from './src/get-translations'
 import getClient from './src/get-client'
+import filterClients from './src/filter-clients'
 import { Translation, TranslationsObject} from './interfaces/translations.interface'
 
-export { getTranslations, getClient }
+export { getTranslations, getClient, filterClients }
 export type { Translation, TranslationsObject }

--- a/src/filter-clients.ts
+++ b/src/filter-clients.ts
@@ -1,0 +1,14 @@
+import * as clients from '../clients'
+import {Client} from '../interfaces/client.interface'
+import {RegistryEntry} from '../interfaces/registry.interface'
+import {transformClientObject} from './utils'
+
+const filterClients = (environment: string, filter: Partial<Client>): RegistryEntry[] => {
+    return Object.values(clients).filter(client => {
+        return Object.keys(filter).some(key => {
+            return client[key as keyof Client] === filter[key as keyof Client];
+        });
+    }).map((client) => transformClientObject(client, environment));
+}
+
+export default filterClients;

--- a/src/get-client.ts
+++ b/src/get-client.ts
@@ -1,20 +1,6 @@
 import * as clients from '../clients'
-import { Client } from '../interfaces/client.interface'
-import { RegistryEntry } from '../interfaces/registry.interface'
-import { getValueForEnvironment } from './utils'
+import {getValueForEnvironment, transformClientObject} from './utils'
 
-const transformClientObject = (client: Client, environment: string): RegistryEntry => {
-    const clientId = getValueForEnvironment(environment, client.clientId)
-    return {
-        clientId,
-        clientType: client.clientType,
-        isAllowed: client.isAllowed,
-        isHmrc: client.isHmrc,
-        isReportSuspiciousActivityEnabled: client.isReportSuspiciousActivityEnabled,
-        isAvailableInWelsh: client.isAvailableInWelsh,
-        showInClientSearch: getValueForEnvironment(environment, client.showInClientSearch),
-    }
-}
 
 const getClient = (environment: string, clientId: string) => {
     const foundEntry = Object.entries(clients).find(([, client]) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { EnvironmentValue } from "../interfaces/client.interface"
+import {Client, EnvironmentValue} from "../interfaces/client.interface"
+import {RegistryEntry} from "../interfaces/registry.interface";
 
 const isEnvironmentObject = <T>(
     value: EnvironmentValue<T>
@@ -37,4 +38,18 @@ const getValueForEnvironment = <T>(environment: string, value: EnvironmentValue<
     return value.nonProduction;
 }
 
-export { getEnvironmentType, getValueForEnvironment }
+const transformClientObject = (client: Client, environment: string): RegistryEntry => {
+    const clientId = getValueForEnvironment(environment, client.clientId)
+    return {
+        clientId,
+        clientType: client.clientType,
+        isAllowed: client.isAllowed,
+        isHmrc: client.isHmrc,
+        isReportSuspiciousActivityEnabled: client.isReportSuspiciousActivityEnabled,
+        isAvailableInWelsh: client.isAvailableInWelsh,
+        showInClientSearch: getValueForEnvironment(environment, client.showInClientSearch),
+    }
+}
+
+
+export { getEnvironmentType, getValueForEnvironment, transformClientObject }

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -1,0 +1,98 @@
+import { expect, test, describe, jest } from '@jest/globals'
+import filterClients from '../src/filter-clients';
+
+jest.mock('../clients', () => ({
+    __esModule: true,
+    cyClient: {
+        isAvailableInWelsh: true,
+        translations: {
+            en: {
+                header: 'header en',
+                linkText: 'link text en',
+                linkUrl: 'link url en',
+            },
+            cy: {
+                header: 'header cy',
+                linkText: 'link text cy',
+                linkUrl: {
+                    production: 'link url cy production',
+                    nonProduction: 'link url cy non production'
+                },
+            }
+        },
+        clientId: {
+            "production": "welshClientProd",
+            "nonProduction": "welshClientNonProd"
+        },
+        clientType: 'account',
+        isAllowed: true,
+        isHmrc: false,
+        isReportSuspiciousActivityEnabled: false,
+        showInClientSearch: true
+    },
+    enClient: {
+        isAvailableInWelsh: false,
+        translations: {
+            en: {
+                header: 'header en',
+                linkText: 'link text en',
+                linkUrl: 'link url en',
+                description: 'description en'
+            },
+        },
+        clientId: 'englishClient',
+        clientType: 'account',
+        isAllowed: true,
+        isHmrc: false,
+        isReportSuspiciousActivityEnabled: false,
+        showInClientSearch: true
+    },
+    hmrcClient: {
+        isAvailableInWelsh: false,
+        translations: {
+            en: {
+                header: 'header en',
+                linkText: 'link text en',
+                linkUrl: 'link url en',
+                description: 'description en',
+                hintText: 'hint text en',
+                paragraph1: 'paragraph 1 en',
+                paragraph2: 'paragraph 2 en'
+            },
+        },
+        clientId: 'hmrcClient',
+        clientType: 'account',
+        isAllowed: true,
+        isHmrc: true,
+        isReportSuspiciousActivityEnabled: false,
+        showInClientSearch: true
+    }
+}));
+
+describe('filterClient', () => {
+    test('should return the client objects that match the given criteria', () => {
+        const client = filterClients('test', { isHmrc: true });
+        expect(client).toEqual([{
+            "clientId": "hmrcClient",
+            "clientType": "account",
+            "isAllowed": true,
+            "isAvailableInWelsh": false,
+            "isHmrc": true,
+            "isReportSuspiciousActivityEnabled": false,
+            "showInClientSearch": true,
+        }]);
+    });
+
+    test('should return correct environment values', () => {
+        const client = filterClients('nonProduction', {isAvailableInWelsh: true});
+        expect(client).toEqual([{
+            "clientId": "welshClientNonProd",
+            "clientType": "account",
+            "isAllowed": true,
+            "isAvailableInWelsh": true,
+            "isHmrc": false,
+            "isReportSuspiciousActivityEnabled": false,
+            "showInClientSearch": true,
+        }]);
+    });
+});


### PR DESCRIPTION
## Proposed changes

OLH-2460 - Add new function to support getting a subset of client registry based on a filter


### What changed

OLH-2460 - Add new function to support getting a subset of client registry based on a filter

### Why did it change

So that we can start using clientRegistry in frontend for hmrc related features.

### Related links

https://govukverify.atlassian.net/browse/OLH-2460

## Checklists


### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing


### Sign-offs


## How to review
